### PR TITLE
Modified the default behavior if no filename is entered

### DIFF
--- a/compiler.py
+++ b/compiler.py
@@ -37,6 +37,9 @@ class MainFileManager():
 
 	def checkExtension(self, name):
 		self.name = name
+		if(self.name == ""):
+			self.name = "main.cs"
+
 		try:
 			self.extension = str(self.name.split('.')[1]).lower()
 		except IndexError:

--- a/compiler.py
+++ b/compiler.py
@@ -94,8 +94,9 @@ class ImporterManager():
 MainFile = MainFileManager()
 MainFile.checkExtension(
 	input(
-		'Enter the name of the final file' +
-		'(with the extension, such as "main.cs"): '
+		'Enter the name of the final file ' +
+		'(with the extension, such as "main.cs"), \n' +
+		'if no filename is entered, "main.cs" will be used: '
 	)
 )
 MainFile.diretory()


### PR DESCRIPTION
Now, if the user presses enter without typing anything, the program will not return an error but will use "main.cs" as the default name.

Another change was that to keep the user informed, the message when entering the final file name was modified.